### PR TITLE
 Fix score copying bug in SensedWorld

### DIFF
--- a/Bomberman/bomberman/sensed_world.py
+++ b/Bomberman/bomberman/sensed_world.py
@@ -51,7 +51,7 @@ class SensedWorld(World):
             if c:
                 new.explosions[k] = ExplosionEntity(oe.x, oe.y, oe.timer, c)
         # Copy scores
-        for name,score in wrld.scores:
+        for name,score in wrld.scores.items():
             new.scores[name] = score
         return new
 


### PR DESCRIPTION
When a SensedWorld is that was created with from_world is used to create another world using the same method, the program crashes when copying scores. I fixed this by using scores.items() when iterating through the scores.