### PR TITLE
Fix bug where char and mon get stuck

### DIFF
--- a/Bomberman/bomberman/monsters/selfpreserving_monster.py
+++ b/Bomberman/bomberman/monsters/selfpreserving_monster.py
@@ -58,7 +58,7 @@ class SelfPreservingMonster(MonsterEntity):
         """Pick an action for the monster"""
         # If a character is in the neighborhood, go to it
         (found, dx, dy) = self.look_for_character(wrld)
-        if found:
+        if found and not self.must_change_direction(wrld):
             self.move(dx, dy)
             return
         # If I'm idle or must change direction, change direction


### PR DESCRIPTION
When testing scenario 1 variant 4, we came across an issue where if the character does not move if it is 2 away from the monster, through a wall, the monster will get stuck because it continuously tries to move up, towards the character and gets stopped at the wall.  This could cause a game to get stuck in an endless loop if the character unfortunately continues to choose to stay where it is.  Here is a screenshot of a position we got stuck in endlessly:
![image](https://user-images.githubusercontent.com/38116068/53460910-cfb0cd80-3a0c-11e9-926f-26518f6c13b6.png)
The bug fix checks to make sure there isn't a wall there before banging the monster against it continuously.
If this pull request is excepted, it would be a bug bounty for Group05