### PR TITLE
Fix 'Event' object has no attribute 'tpe'

### DIFF
--- a/Bomberman/bomberman/game.py
+++ b/Bomberman/bomberman/game.py
@@ -123,7 +123,7 @@ class Game:
     def done(self):
         # User Exit
         for event in pygame.event.get():
-            if event.tpe == pygame.QUIT:
+            if event.type == pygame.QUIT:
                 return True
         # Time's up
         if self.world.time <= 0:


### PR DESCRIPTION
The event object referenced in game.py (line 126) is a PyGame event, and not a Bomberman event. This leads to:
```
Traceback (most recent call last):
  File "C:/***", line 35, in <module>
    g.go(10)
  File "../../bomberman\game.py", line 108, in go
    while not self.done():
  File "../../bomberman\game.py", line 126, in done
    if event.tpe == pygame.QUIT:
AttributeError: 'Event' object has no attribute 'tpe'
```

I have reverted the change, and it seems to work for us now. Tested by cloning the original repo, making the change back to `event.type`, and running variant_1.py.