### PR TITLE
Fixed remove_character() leaving empty indexes

### DIFF
--- a/Bomberman/bomberman/world.py
+++ b/Bomberman/bomberman/world.py
@@ -149,6 +149,8 @@ class World:
         i = self.index(character.x, character.y)
         if (i in self.characters) and (character in self.characters[i]):
             self.characters[i].remove(character)
+            if not self.characters[i]:
+                del self.characters[i]
 
     def check_blast(self, bomb, x, y):
         # Check if a wall has been hit


### PR DESCRIPTION
When a monster kills a character, the character is removed only after update_characters(), so the characters dictionary can end up having indexes that have empty character lists, like this: `{40: []}`.

This can cause the condition `not self.world.characters` in game.done() and a similar condition in our group's terminal state checks to return False when there are no characters instead of True.

I added a couple lines to world.remove_character() to check if the removed character leaves its list empty, and if so deletes the index. Tested by printing the result of `not wrld.characters` in a sensed world where the monster kills the player in Variant 2 of Scenario 2, and it seems to work now.